### PR TITLE
Support for requests with base path

### DIFF
--- a/src/BlazorServerUrlRequestCultureProvider/HttpContextExtensions.cs
+++ b/src/BlazorServerUrlRequestCultureProvider/HttpContextExtensions.cs
@@ -7,7 +7,7 @@ namespace BlazorServerUrlRequestCultureProvider
     public static class HttpContextExtensions
     {
         public static string GetCultureFromRequest(this HttpContext httpContext)
-            => GetCultureFromPath(httpContext.Request.Path.Value);
+            => GetCultureFromPath(httpContext.Request.Path.Value, httpContext.Request.PathBase.Value);
         
 
         public static string GetCultureFromReferer(this HttpContext httpContext)
@@ -15,11 +15,16 @@ namespace BlazorServerUrlRequestCultureProvider
             var referer = httpContext.Request.Headers["Referer"].ToString();
             var uri = new Uri(referer);
 
-            return GetCultureFromPath(uri.LocalPath);
+            return GetCultureFromPath(uri.LocalPath, httpContext.Request.PathBase.Value);
         }
 
-        private static string GetCultureFromPath(string path)
+        private static string GetCultureFromPath(string path, string pathBase)
         {
+            if (!string.IsNullOrEmpty(pathBase) && path.StartsWith(pathBase, StringComparison.OrdinalIgnoreCase))
+            {
+                path = path.Substring(pathBase.Length);
+            }
+
             var segments = path.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
 
             if (segments.Length >= 1 && segments[0].Length == 2)

--- a/tests/BlazorServerUrlRequestCultureProvider.UnitTests/UrlLocalizationAwareWebSocketsMiddlewareTests/GetCultureFromRefererTests.cs
+++ b/tests/BlazorServerUrlRequestCultureProvider.UnitTests/UrlLocalizationAwareWebSocketsMiddlewareTests/GetCultureFromRefererTests.cs
@@ -82,5 +82,32 @@ namespace BlazorServerUrlRequestCultureProvider.UnitTests
                 Assert.Equal(twoLetterISOLanguageName, CultureInfo.CurrentCulture.TwoLetterISOLanguageName);
             }
         }
+
+        [Theory]
+        [InlineData("en", "/app1")]
+        [InlineData("fr", "/app1")]
+        public async Task When_cluture_is_set_with_path_base(string twoLetterISOLanguageName, string pathBase)
+        {
+            // Arrange
+            _context.Request.Headers["Referer"] = $"http://example.com{pathBase}/{twoLetterISOLanguageName}/";
+            _context.Request.PathBase = pathBase;
+
+            RequestDelegate next = (HttpContext hc) =>
+            {
+                Asserter();
+                return Task.CompletedTask;
+            };
+
+            var sutMiddleware = new UrlLocalizationAwareWebSocketsMiddleware(next);
+
+            // Act
+            await sutMiddleware.InvokeAsync(_context);
+
+            // Assert
+            void Asserter()
+            {
+                Assert.Equal(twoLetterISOLanguageName, CultureInfo.CurrentCulture.TwoLetterISOLanguageName);
+            }
+        }
     }
 }


### PR DESCRIPTION
When running a blazor server website in a 'subfolder' (e.g. with nginx reverse proxy) support for base path seems necessary.